### PR TITLE
replace deprecated istree with iscall

### DIFF
--- a/src/SymbolicNumericIntegration.jl
+++ b/src/SymbolicNumericIntegration.jl
@@ -1,7 +1,7 @@
 module SymbolicNumericIntegration
 
 using SymbolicUtils
-using SymbolicUtils: istree, operation, arguments
+using SymbolicUtils: iscall, operation, arguments
 using Symbolics
 using Symbolics: value, get_variables, expand_derivatives, coeff, Equation
 using SymbolicUtils.Rewriters

--- a/src/rules.jl
+++ b/src/rules.jl
@@ -278,7 +278,7 @@ h_rules = [@rule +(~~xs) => ω + sum(~~xs)
 # it is roughly similar ro kolmogorov complexity
 function complexity(eq)
     eq = value(eq)
-    if istree(eq)
+    if iscall(eq)
         return 1 + sum(complexity(t) for t in args(eq))
     elseif is_number(eq)
         return abs(eq)

--- a/src/tree.jl
+++ b/src/tree.jl
@@ -2,22 +2,22 @@
 
 function is_add(eq)
     y = value(eq)
-    return istree(y) && exprtype(y) == SymbolicUtils.ADD
+    return iscall(y) && exprtype(y) == SymbolicUtils.ADD
 end
 
 function is_mul(eq)
     y = value(eq)
-    return istree(y) && exprtype(y) == SymbolicUtils.MUL
+    return iscall(y) && exprtype(y) == SymbolicUtils.MUL
 end
 
 function is_pow(eq)
     y = value(eq)
-    return istree(y) && exprtype(y) == SymbolicUtils.POW
+    return iscall(y) && exprtype(y) == SymbolicUtils.POW
 end
 
 function is_div(eq)
     y = value(eq)
-    return istree(y) && exprtype(y) == SymbolicUtils.DIV
+    return iscall(y) && exprtype(y) == SymbolicUtils.DIV
 end
 
 is_term(eq) = SymbolicUtils.isterm(value(eq))
@@ -25,7 +25,7 @@ is_term(eq) = SymbolicUtils.isterm(value(eq))
 
 function args(eq)
     eq = value(eq)
-    return istree(eq) ? arguments(eq) : []
+    return iscall(eq) ? arguments(eq) : []
 end
 
 diff(eq, x) = expand_derivatives(Differential(x)(eq))

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -99,7 +99,7 @@ end
 # pox(k,n) means k*x^n
 @syms pox(k, n)
 
-is_pox(x) = istree(x) && operation(x) == pox
+is_pox(x) = iscall(x) && operation(x) == pox
 is_not_pox(x) = !is_pox(x)
 
 get_coef(p) = is_pox(p) ? arguments(p)[1] : p
@@ -127,7 +127,7 @@ function collect_powers(eq, x)
     #eq = Prewalk(PassThrough(count_rule1))(eq)
     eq = Fixpoint(Prewalk(PassThrough(Chain([count_rule1, count_rule2, count_rule3]))))(eq)
 
-    if !istree(eq)
+    if !iscall(eq)
         return Dict{Any, Any}(0 => eq)
     elseif is_pox(eq)
         return Dict{Any, Any}(get_power(eq) => get_coef(eq))


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

This replaces all calls to `SymbolicUtils` deprectated `istree` with `iscall`.
