### PR TITLE
[doc] fix typo

### DIFF
--- a/src/integral.jl
+++ b/src/integral.jl
@@ -10,7 +10,7 @@ Base.signbit(x::SymbolicUtils.Sym{Number}) = false
 is the main entry point to integrate a univariate expression `eq` with respect to `x' (optional).
 
 ```julia
-julia> using Symbolics, SymbolNumericIntegration
+julia> using Symbolics, SymbolicNumericIntegration
 
 julia> @variables x a
 


### PR DESCRIPTION
## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context
copy-paste example in doc has a typo: `SymbolNumericIntegration`

Add any other context about the problem here.
