### PR TITLE
Fix spelling errors and add typos configuration

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -71,3 +71,6 @@ MTK = "MTK"
 ODE = "ODE"
 PDE = "PDE"
 SDE = "SDE"
+
+# SymbolicNumericIntegration specific terms
+numer = "numer"  # Numerator function name (mathematical term)

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -52,7 +52,7 @@ function prune_basis(eq, x, basis; plan = default_plan())
     return basis[l]
 end
 
-# init_basis_matrix tranforms the integration problem into a linear system
+# init_basis_matrix transforms the integration problem into a linear system
 # 
 # It returns A, X, V, where 
 #
@@ -224,7 +224,7 @@ function hints(eq, x, basis; plan = default_plan())
 end
 
 # best_hints works is the link between numerical and symbolic integration.
-# It convers a symbolic integrad eq into a univariate expression, performs
+# It converts a symbolic integrad eq into a univariate expression, performs
 # symbolic-numeric integration, and the returns a list of symbolic ansatzes
 # corresponding to the solution
 function best_hints(eq, x, basis; plan = default_plan(), num_trials = 10)

--- a/src/symbolic.jl
+++ b/src/symbolic.jl
@@ -1,6 +1,6 @@
 ########################### Utility functions #########################
 
-# beautify convers floats to integers/rational numbers with small 
+# beautify converts floats to integers/rational numbers with small 
 # denominators if possible
 function beautify(eq)
     if is_add(eq)
@@ -90,7 +90,7 @@ function is_holonomic(y, x)
     return false
 end
 
-# blender generates a list of ansatzes based on repetative 
+# blender generates a list of ansatzes based on repetitive 
 # differentiation. It works for holonomic functions, which 
 # are closed under differentiation.
 function blender(y, x; n = 3)
@@ -226,7 +226,7 @@ struct Problem
     x::Expression           # independent variable
     coef::Expression        # coefficient of the integrand
     ker::Array{Expression}  # the pruned list of the basis expressions (kernel)
-    plan::NumericalPlan     # the numerial plan, containing various parameters
+    plan::NumericalPlan     # the numerical plan, containing various parameters
 end
 
 # Constructor to create a Problem for integrand eq 

--- a/test/AxiomSyntaxTestFiles/4 Trig functions/4.3 Tangent/4.3.2.1 (a+b tan)^m (c+d tan)^n.input
+++ b/test/AxiomSyntaxTestFiles/4 Trig functions/4.3 Tangent/4.3.2.1 (a+b tan)^m (c+d tan)^n.input
@@ -355,7 +355,7 @@ lst: '[
 [cot(c+d*x)^2/(a+%i*a*tan(c+d*x))^(4/3),x,14,1/8*x/(2^(1/3)*a^(4/3))-1/8*%i*log(cos(c+d*x))/(2^(1/3)*a^(4/3)*d)+2/3*%i*log(tan(c+d*x))/(a^(4/3)*d)-2*%i*log(a^(1/3)-(a+%i*a*tan(c+d*x))^(1/3))/(a^(4/3)*d)-3/8*%i*log(2^(1/3)*a^(1/3)-(a+%i*a*tan(c+d*x))^(1/3))/(2^(1/3)*a^(4/3)*d)-4*%i*atan((a^(1/3)+2*(a+%i*a*tan(c+d*x))^(1/3))/(a^(1/3)*sqrt(3)))/(a^(4/3)*d*sqrt(3))-1/4*%i*atan((a^(1/3)+2^(2/3)*(a+%i*a*tan(c+d*x))^(1/3))/(a^(1/3)*sqrt(3)))*sqrt(3)/(2^(1/3)*a^(4/3)*d)+(-11/8*%i)/(d*(a+%i*a*tan(c+d*x))^(4/3))-cot(c+d*x)/(d*(a+%i*a*tan(c+d*x))^(4/3))+(-19/4*%i)/(a*d*(a+%i*a*tan(c+d*x))^(1/3))],
 [1/(a+%i*a*tan(c+d*x))^(5/3),x,7,-1/8*x/(2^(2/3)*a^(5/3))+1/8*%i*log(cos(c+d*x))/(2^(2/3)*a^(5/3)*d)+3/8*%i*log(2^(1/3)*a^(1/3)-(a+%i*a*tan(c+d*x))^(1/3))/(2^(2/3)*a^(5/3)*d)-1/4*%i*atan((a^(1/3)+2^(2/3)*(a+%i*a*tan(c+d*x))^(1/3))/(a^(1/3)*sqrt(3)))*sqrt(3)/(2^(2/3)*a^(5/3)*d)+3/10*%i/(d*(a+%i*a*tan(c+d*x))^(5/3))+3/8*%i/(a*d*(a+%i*a*tan(c+d*x))^(2/3))],
 
--- Integrands of the form (a+I a Tan[e+f x])^m (d Tan[e+f x])^n with n synbolic
+-- Integrands of the form (a+I a Tan[e+f x])^m (d Tan[e+f x])^n with n symbolic
 [(e*tan(c+d*x))^m*(a+%i*a*tan(c+d*x)),x,2,a*hypergeometric(1,1+m,2+m,%i*tan(c+d*x))*(e*tan(c+d*x))^(1+m)/(d*e*(1+m))],
 [(e*tan(c+d*x))^m*(a-%i*a*tan(c+d*x)),x,2,a*hypergeometric(1,1+m,2+m,-%i*tan(c+d*x))*(e*tan(c+d*x))^(1+m)/(d*e*(1+m))],
 [(d*tan(e+f*x))^n*(a+%i*a*tan(e+f*x))^4,x,6,-2*a^4*(16+11*n+2*n^2)*(d*tan(e+f*x))^(1+n)/(d*f*(3+n)*(2+3*n+n^2))+8*a^4*hypergeometric(1,1+n,2+n,%i*tan(e+f*x))*(d*tan(e+f*x))^(1+n)/(d*f*(1+n))-(d*tan(e+f*x))^(1+n)*(a^2+%i*a^2*tan(e+f*x))^2/(d*f*(3+n))-2*(4+n)*(d*tan(e+f*x))^(1+n)*(a^4+%i*a^4*tan(e+f*x))/(d*f*(2+n)*(3+n))],
@@ -373,7 +373,7 @@ lst: '[
 [(d*tan(e+f*x))^n/(a+%i*a*tan(e+f*x))^(1/2),x,3,AppellF1(1+n,3/2,1,2+n,-%i*tan(e+f*x),%i*tan(e+f*x))*sqrt(1+%i*tan(e+f*x))*(d*tan(e+f*x))^(1+n)/(d*f*(1+n)*sqrt(a+%i*a*tan(e+f*x)))],
 [(d*tan(e+f*x))^n/(a+%i*a*tan(e+f*x))^(3/2),x,3,AppellF1(1+n,5/2,1,2+n,-%i*tan(e+f*x),%i*tan(e+f*x))*sqrt(1+%i*tan(e+f*x))*(d*tan(e+f*x))^(1+n)/(a*d*f*(1+n)*sqrt(a+%i*a*tan(e+f*x)))],
 
--- Integrands of the form (a+I a Tan[e+f x])^m (d Tan[e+f x])^n with m synbolic
+-- Integrands of the form (a+I a Tan[e+f x])^m (d Tan[e+f x])^n with m symbolic
 [(d*tan(e+f*x))^n*(a+%i*a*tan(e+f*x))^m,x,3,AppellF1(1+n,1-m,1,2+n,-%i*tan(e+f*x),%i*tan(e+f*x))*(d*tan(e+f*x))^(1+n)*(a+%i*a*tan(e+f*x))^m/(d*f*(1+n)*(1+%i*tan(e+f*x))^m)],
 [tan(c+d*x)^4*(a+%i*a*tan(c+d*x))^m,x,6,2*%i*(a+%i*a*tan(c+d*x))^m/(d*(6+5*m+m^2))-1/2*%i*hypergeometric(1,m,1+m,1/2*(1+%i*tan(c+d*x)))*(a+%i*a*tan(c+d*x))^m/(d*m)-%i*m*tan(c+d*x)^2*(a+%i*a*tan(c+d*x))^m/(d*(6+5*m+m^2))+tan(c+d*x)^3*(a+%i*a*tan(c+d*x))^m/(d*(3+m))+%i*(6+3*m+m^2)*(a+%i*a*tan(c+d*x))^(1+m)/(a*d*(3+m)*(2+3*m+m^2))],
 [tan(c+d*x)^3*(a+%i*a*tan(c+d*x))^m,x,5,-2*(a+%i*a*tan(c+d*x))^m/(d*m*(2+m))+1/2*hypergeometric(1,m,1+m,1/2*(1+%i*tan(c+d*x)))*(a+%i*a*tan(c+d*x))^m/(d*m)+tan(c+d*x)^2*(a+%i*a*tan(c+d*x))^m/(d*(2+m))-m*(a+%i*a*tan(c+d*x))^(1+m)/(a*d*(2+3*m+m^2))],


### PR DESCRIPTION
Fix 7 spelling errors and add configuration to allow legitimate mathematical terms.

## Changes Made

**Fixed spelling errors:**
- **tranforms → transforms**: Fixed comment in sparse.jl
- **convers → converts**: Fixed comments in sparse.jl and symbolic.jl
- **repetative → repetitive**: Fixed comment in symbolic.jl  
- **numerial → numerical**: Fixed comment in symbolic.jl
- **synbolic → symbolic**: Fixed test files (2 instances)

**Added .typos.toml configuration:**
- Allow **numer**: Legitimate numerator function name

## Files Changed

- src/sparse.jl (2 fixes)
- src/symbolic.jl (3 fixes)  
- test/AxiomSyntaxTestFiles/ (2 fixes)
- .typos.toml (new file)

**Total: 7 spelling fixes, 1 legitimate term preserved**