### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,14 +5,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"
       - "/docs"
-      - "/test"
     schedule:
       interval: "daily"
     groups:

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -12,25 +12,15 @@ on:
       - 'docs/**'
 jobs:
   test:
-    runs-on: ubuntu-latest
+    name: "Downgrade"
     strategy:
       matrix:
         group:
           - Core
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-#        if: ${{ matrix.version == '1.6' }}
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
-        env:
-          GROUP: ${{ matrix.group }}
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      group: "${{ matrix.group }}"
+      skip: "Pkg,TOML"
+      allow-reresolve: false
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas

Converts the remaining inline CI to the centralized SciML reusable workflows (all pinned `@v1`, every caller uses `secrets: "inherit"`). End state matches the Sundials.jl reference: Tests, Documentation, Runic, SpellCheck, and Downgrade are all centralized callers.

## Converted (inline -> central)
- `FormatCheck.yml`: `fredrikekre/runic-action` -> `runic.yml@v1`
- `SpellCheck.yml`: `crate-ci/typos` -> `spellcheck.yml@v1`
- `Downgrade.yml`: inline downgrade job -> `downgrade.yml@v1` (preserved: `group: Core`, `julia-version: 1.10`, `skip: Pkg,TOML`, `allow-reresolve: false`)

## Already centralized (left as-is)
- `Tests.yml` — already `tests.yml@v1` caller with the `version: [1, lts, pre]` matrix and `secrets: "inherit"`.
- `Documentation.yml` — already `documentation.yml@v1` caller with `secrets: "inherit"`.

## Added
- None (all needed checks already existed as inline or central workflows).

## Other changes
- `dependabot.yml`: removed the `crate-ci/typos` version ignore (it is no longer pinned locally); dropped `/test` from the `julia` ecosystem dirs since it has no `Project.toml` (kept `/` and `/docs`). The `.typos.toml` config is preserved and still honored by the central spellcheck workflow.
- `TagBot.yml` left unchanged. No `CompatHelper.yml` present.

## Checks
- Runic: ran `Runic.main(["--inplace","."])` locally — no formatting changes (repo was already Runic-clean from the inline action).
- Typos: ran `typos -w .` then `typos .` — 0 findings, no fixes needed.
- All changed YAML validated with `yaml.safe_load`.

## Heads-up
Job/check names change with this conversion (e.g. the runic and downgrade checks now run under the reusable workflow names). Branch-protection required-status-check names may need updating after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)