### PR TITLE
Fix malformed [extras]/[targets] in Project.toml breaking all CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -28,11 +28,15 @@ SymbolicLimits = "0.2.4, 1.1"
 SymbolicUtils = "4.20.1"
 Symbolics = "7.12.0"
 TermInterface = "2"
-Pkg = "1"
 SafeTestsets = "0.1, 1"
 SciMLTesting = "1"
 Test = "1"
 julia = "1.10"
 
 [extras]
-test = ["SciMLTesting", "Test", "Pkg", "SafeTestsets"]
+SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["SafeTestsets", "SciMLTesting", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,7 @@ using Symbolics
 using SymbolicUtils
 using SymbolicUtils.Rewriters
 
+using SafeTestsets
 using SciMLTesting
 
 run_tests(;


### PR DESCRIPTION
## Problem

Every CI job on `main` (Core, QA, Documentation, and Downgrade) is failing at the `Pkg.build` step on Julia 1.12 with:

```
ERROR: LoadError: TypeError: in typeassert, expected String, got a value of type Vector{String}
  [1] get_uuid_name(project::Dict{String, Any}, uuid::Base.UUID)  @ Base ./loading.jl:3694
  [2] collect_preferences(project_toml::String, uuid::Base.UUID)  @ Base ./loading.jl:3729
  [3] get_preferences(uuid::Base.UUID)                            @ Base ./loading.jl:3813
  [4] get_preferences_hash(uuid::Base.UUID, prefs_list::Vector{String})
```

(The Documentation job shows the same root cause surfaced differently: `MethodError: Cannot convert Vector{String} to UInt128`, i.e. a UUID parse on the same value.)

## Root cause

The `[extras]` section of `Project.toml` was malformed. The test-target line was placed directly under `[extras]`:

```toml
[extras]
test = ["SciMLTesting", "Test", "Pkg", "SafeTestsets"]
```

That is the `[targets]` form, not an `[extras]` entry. `[extras]` must map package names to UUID strings. None of `SciMLTesting`/`Test`/`Pkg`/`SafeTestsets` were declared with UUIDs, and there was no `[targets]` header, so the loader saw `[extras]` mapping the key `test` to a `Vector{String}`.

Julia's `Base.get_uuid_name` (`loading.jl:3694`) iterates `[extras]` doing `UUID(v::String)`. With `v` being a `Vector{String}` this throws the `typeassert` error. Because preference-hash collection runs during the precompile staleness check, this breaks **all** package loading — hence every job dies at `Pkg.build`.

This was introduced by #159, which changed the target list but dropped the UUID declarations and `[targets]` header.

## Fix

- Declare the test dependencies under `[extras]` with their UUIDs:
  - `SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"`
  - `SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"`
  - `Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"`
- Move the target list under a proper `[targets]` section.
- Drop the unused `Pkg` `[compat]` entry — `Pkg` is not referenced anywhere in `test/` or `src/`.

UUIDs verified against the General registry.

## Local verification

On `julia +1.12` (1.12.6) — the same minor version CI uses:

- Before: `Pkg.instantiate()` reproduced the exact `TypeError: ... got Vector{String}` in `get_uuid_name`.
- After: `Pkg.instantiate()` precompiles cleanly (186 deps incl. `SymbolicNumericIntegration`), prints `INSTANTIATE_OK`, and `using SymbolicNumericIntegration` prints `LOAD_OK`.

Please ignore until reviewed by @ChrisRackauckas.
