### PR TITLE
Fix QA test group routing (GROUP="QA" had no qa body)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,8 +22,5 @@ run_tests(;
             include("definite_integral_tests.jl")
         end
     end,
-    groups = Dict(
-        # declared env => runs only for GROUP="QA", never under "All" (matches original)
-        "QA" => (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
-    ),
+    qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
 )


### PR DESCRIPTION
The `tests / QA` jobs on `main` (both Julia `1` and `lts`) fail at startup with:

```
ERROR: LoadError: ArgumentError: run_tests: GROUP="QA" was requested but no `qa` body was provided
```

## Root cause

`test/runtests.jl` declared the QA group as a `"QA"` key inside the `groups` Dict passed to `SciMLTesting.run_tests`. But `"QA"` is a **reserved group name** in SciMLTesting (alongside `All`/`Core`). When `GROUP="QA"` is requested, `run_tests` dispatches to its dedicated `qa` keyword argument — it never consults `groups["QA"]`. With `qa` left unset, the reserved-name branch throws the `ArgumentError` above before the `groups` table is reached, so the Aqua/JET bodies never run.

Core was green because `core` was passed correctly; only QA was misrouted.

## Fix

Move the QA spec out of `groups` and into the dedicated `qa` keyword, matching the canonical single-package form in the SciMLTesting docstring:

```julia
qa = (; env = joinpath(@__DIR__, "qa"), body = joinpath(@__DIR__, "qa", "qa.jl")),
```

No change to `test/qa/qa.jl` (Aqua + JET) or `test/test_groups.toml`.

## Local verification

Against **released SciMLTesting v1** on **Julia 1.12** (the `1` CI channel):

- Old `groups = Dict("QA" => ...)` form → reproduces the exact CI `ArgumentError`.
- New `qa = (; env, body)` form → `GROUP="QA"` routes to and runs the QA body.
- Sanity: `GROUP="Core"` still runs only `core`, QA does not run (no regression to the passing Core group).

Please ignore until reviewed by @ChrisRackauckas