### PR TITLE
QA: run_qa v1.6 form + ExplicitImports

### DIFF
--- a/src/SymbolicNumericIntegration.jl
+++ b/src/SymbolicNumericIntegration.jl
@@ -5,7 +5,7 @@ using TermInterface: iscall
 using SymbolicUtils
 using SymbolicUtils: operation, arguments
 using Symbolics
-using Symbolics: value, get_variables, expand_derivatives, coeff, Equation
+using Symbolics: value, get_variables, expand_derivatives, Equation
 using SymbolicUtils.Rewriters
 using SymbolicUtils: issym, BasicSymbolic
 

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -1,7 +1,7 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
-SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
+SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 SymbolicNumericIntegration = "78aadeae-fbc0-11eb-17b6-c7ec0477ba9e"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -11,5 +11,6 @@ SymbolicNumericIntegration = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
+SciMLTesting = "1.6"
 Test = "1"
 julia = "1.10"

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -11,6 +11,6 @@ SymbolicNumericIntegration = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
-SciMLTesting = "1.6"
+SciMLTesting = "1.7"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -19,16 +19,11 @@ run_qa(
         ),
         # Non-public names of upstream packages accessed via qualification.
         # AbstractDataDrivenAlgorithm: DataDrivenDiffEq; active_set!, coef:
-        # DataDrivenSparse; Sym: SymbolicUtils; toexpr: Symbolics.
+        # DataDrivenSparse; toexpr: Symbolics.
         all_qualified_accesses_are_public = (;
             ignore = (
-                :AbstractDataDrivenAlgorithm, :Sym, :active_set!, :coef, :toexpr,
+                :AbstractDataDrivenAlgorithm, :active_set!, :coef, :toexpr,
             ),
-        ),
-        # Non-public names explicitly imported from upstream packages.
-        # issym: SymbolicUtils.
-        all_explicit_imports_are_public = (;
-            ignore = (:issym,),
         ),
     ),
     # Heavy `using` of the Symbolics/SymbolicUtils/DataDriven stacks (macros +

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -1,18 +1,41 @@
-using SafeTestsets
+using SymbolicNumericIntegration, Test
+using JET
+using SciMLTesting
 
-@safetestset "Aqua" begin
-    using SymbolicNumericIntegration
-    using Aqua
-    using Test
-
-    Aqua.test_all(SymbolicNumericIntegration; piracies = false)
-    @test_broken false  # Aqua piracy: Base.signbit(::Complex)/signbit(::SymbolicUtils.Sym) in src/integral.jl + DataDrivenSparse.active_set! in src/sparse.jl — see https://github.com/SciML/SymbolicNumericIntegration.jl/issues/156
-end
-
-@safetestset "JET" begin
-    using SymbolicNumericIntegration
-    using JET
-    using Test
-
-    JET.test_package(SymbolicNumericIntegration; target_defined_modules = true)
-end
+run_qa(
+    SymbolicNumericIntegration;
+    explicit_imports = true,
+    jet_kwargs = (; target_defined_modules = true),
+    # Aqua piracy: Base.signbit(::Complex)/signbit(::SymbolicUtils.Sym) in
+    # src/integral.jl + DataDrivenSparse.active_set! in src/sparse.jl
+    # https://github.com/SciML/SymbolicNumericIntegration.jl/issues/156
+    aqua_broken = (:piracies,),
+    ei_kwargs = (;
+        # Re-exports: accessed from the re-exporting module rather than the owner.
+        # coef -> StatsAPI (via DataDrivenSparse); scalarize/toexpr/unwrap ->
+        # SymbolicUtils[.Code] (via Symbolics).
+        all_qualified_accesses_via_owners = (;
+            ignore = (:coef, :scalarize, :toexpr, :unwrap),
+        ),
+        # Non-public names of upstream packages accessed via qualification.
+        # AbstractDataDrivenAlgorithm: DataDrivenDiffEq; active_set!, coef:
+        # DataDrivenSparse; Sym: SymbolicUtils; derivative, scalarize, toexpr,
+        # unwrap, value: Symbolics.
+        all_qualified_accesses_are_public = (;
+            ignore = (
+                :AbstractDataDrivenAlgorithm, :Sym, :active_set!, :coef,
+                :derivative, :scalarize, :toexpr, :unwrap, :value,
+            ),
+        ),
+        # Non-public names explicitly imported from upstream packages.
+        # BasicSymbolic, issym: SymbolicUtils; get_variables, value: Symbolics.
+        all_explicit_imports_are_public = (;
+            ignore = (:BasicSymbolic, :issym, :get_variables, :value),
+        ),
+    ),
+    # Heavy `using` of the Symbolics/SymbolicUtils/DataDriven stacks (macros +
+    # module bindings used for qualified access) — tracked for a follow-up
+    # explicit-import pass rather than a risky mass refactor.
+    # https://github.com/SciML/SymbolicNumericIntegration.jl/issues/164
+    ei_broken = (:no_implicit_imports,),
+)

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -12,10 +12,10 @@ run_qa(
     aqua_broken = (:piracies,),
     ei_kwargs = (;
         # Re-exports: accessed from the re-exporting module rather than the owner.
-        # coef -> StatsAPI (via DataDrivenSparse); scalarize/toexpr/unwrap ->
-        # SymbolicUtils[.Code] (via Symbolics).
+        # coef -> StatsAPI (via DataDrivenSparse); toexpr -> SymbolicUtils.Code
+        # (via Symbolics). Neither owner is a SciML make-public target.
         all_qualified_accesses_via_owners = (;
-            ignore = (:coef, :scalarize, :toexpr, :unwrap),
+            ignore = (:coef, :toexpr),
         ),
         # Non-public names of upstream packages accessed via qualification.
         # AbstractDataDrivenAlgorithm: DataDrivenDiffEq; active_set!, coef:

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -19,18 +19,16 @@ run_qa(
         ),
         # Non-public names of upstream packages accessed via qualification.
         # AbstractDataDrivenAlgorithm: DataDrivenDiffEq; active_set!, coef:
-        # DataDrivenSparse; Sym: SymbolicUtils; derivative, scalarize, toexpr,
-        # unwrap, value: Symbolics.
+        # DataDrivenSparse; Sym: SymbolicUtils; toexpr: Symbolics.
         all_qualified_accesses_are_public = (;
             ignore = (
-                :AbstractDataDrivenAlgorithm, :Sym, :active_set!, :coef,
-                :derivative, :scalarize, :toexpr, :unwrap, :value,
+                :AbstractDataDrivenAlgorithm, :Sym, :active_set!, :coef, :toexpr,
             ),
         ),
         # Non-public names explicitly imported from upstream packages.
-        # BasicSymbolic, issym: SymbolicUtils; get_variables, value: Symbolics.
+        # issym: SymbolicUtils.
         all_explicit_imports_are_public = (;
-            ignore = (:BasicSymbolic, :issym, :get_variables, :value),
+            ignore = (:issym,),
         ),
     ),
     # Heavy `using` of the Symbolics/SymbolicUtils/DataDriven stacks (macros +


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

Brings `test/qa/qa.jl` onto SciMLTesting 1.6's `run_qa` and enables the ExplicitImports checks (`explicit_imports = true`). Replaces the hand-rolled `SafeTestsets` + `Aqua.test_all` + `JET.test_package` layout.

## What changed

- `test/qa/qa.jl`: `run_qa(SymbolicNumericIntegration; explicit_imports = true, jet_kwargs = (; target_defined_modules = true), aqua_broken = (:piracies,), ei_kwargs = (...), ei_broken = (:no_implicit_imports,))`.
- `test/qa/Project.toml`: add `SciMLTesting` (`compat "1.6"`), drop `SafeTestsets` (run_qa owns the testset). `ExplicitImports` is transitive via SciMLTesting; `Aqua` stays a direct dep because its `ambiguities` sub-check spawns a child process.
- `src/SymbolicNumericIntegration.jl`: drop the unused `coeff` from `using Symbolics: ...` (was a stale explicit import).

## Preserved tracked-broken findings

- Aqua `piracies` -> `aqua_broken = (:piracies,)` (was `piracies = false` + `@test_broken false`). Tracked in #156.

## ExplicitImports findings (Julia 1.10, ExplicitImports 1.15.0)

- `no_stale_explicit_imports`: **fixed** by removing `coeff`.
- `all_explicit_imports_via_owners`: passes.
- `all_qualified_accesses_via_owners`: ignore `:coef, :scalarize, :toexpr, :unwrap` (re-exports — `coef` owned by StatsAPI via DataDrivenSparse; `scalarize/toexpr/unwrap` owned by SymbolicUtils[.Code] via Symbolics).
- `all_qualified_accesses_are_public`: ignore 9 upstream non-public names (DataDrivenDiffEq `AbstractDataDrivenAlgorithm`; DataDrivenSparse `active_set!`, `coef`; SymbolicUtils `Sym`; Symbolics `derivative`, `scalarize`, `toexpr`, `unwrap`, `value`).
- `all_explicit_imports_are_public`: ignore 4 upstream non-public names (SymbolicUtils `BasicSymbolic`, `issym`; Symbolics `get_variables`, `value`).
- `no_implicit_imports`: many heavy-`using` names across the Symbolics / SymbolicUtils / DataDriven stacks (macros + module bindings used for qualified access). Marked `ei_broken = (:no_implicit_imports,)` and tracked in #164 rather than a risky mass `using X: name` refactor.

## Local verification

Ran the QA group against **released** SciMLTesting 1.6.0 (no dev-from-branch), local source developed into the qa env:

```
Test Summary:     | Pass  Broken  Total     Time
Quality Assurance |   16       2     18  2m40.0s
```

0 Fail / 0 Error. The 2 Broken are the intended `piracies` (#156) and `no_implicit_imports` (#164) placeholders; both auto-flag an Unexpected Pass once fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)