### PR TITLE
Bump version to 1.11.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicNumericIntegration"
 uuid = "78aadeae-fbc0-11eb-17b6-c7ec0477ba9e"
 authors = ["Shahriar Iravanian <siravan@svtsim.com>"]
-version = "1.11.0"
+version = "1.11.1"
 
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"


### PR DESCRIPTION
Automated patch version bump (1.11.0 -> 1.11.1) to release unreleased commits on `main` via JuliaRegistrator.