### PR TITLE
Update SciMLTesting QA docs checks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,7 +29,7 @@ SymbolicUtils = "4.20.1"
 Symbolics = "7.12.0"
 TermInterface = "2"
 SafeTestsets = "0.1, 1"
-SciMLTesting = "1"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"
 

--- a/docs/src/symbolicnumericintegration.md
+++ b/docs/src/symbolicnumericintegration.md
@@ -2,4 +2,10 @@
 
 ```@docs
 integrate
+Ei
+Si
+Ci
+Li
+generate_basis
+best_hints
 ```

--- a/docs/theory.ipynb
+++ b/docs/theory.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this section, we informally introduce the symbolic-numeric integration algorithm, as implemented by **SymbolicNumericIntegraion.jl**."
+    "In this section, we informally introduce the symbolic-numeric integration algorithm, as implemented by **SymbolicNumericIntegration.jl**."
    ]
   },
   {
@@ -47,7 +47,7 @@
     "  \\tag{3}\n",
     "\\end{equation}\n",
     "\n",
-    "By definition, $\\int S\\,dx = f$; therefore, $S' = f = x \\sin x$ (note that, as it is customary in symbolic integration, we ignore the constant inegration term). We obtain the following linear system,\n",
+    "By definition, $\\int S\\,dx = f$; therefore, $S' = f = x \\sin x$ (note that, as it is customary in symbolic integration, we ignore the constant integration term). We obtain the following linear system,\n",
     "\n",
     "\\begin{equation}\n",
     "  \\begin{array}{ll}\n",

--- a/src/candidates.jl
+++ b/src/candidates.jl
@@ -1,6 +1,11 @@
 using DataStructures
 
-# this is the old heurisctic used to find the test fragments
+"""
+    generate_basis(eq, x, try_kernel = true)
+
+Generate candidate basis terms for symbolic-numeric integration of expression
+`eq` with respect to variable `x`.
+"""
 function generate_basis(eq, x, try_kernel = true)
     if !try_kernel
         S = sum(generate_homotopy(expr(eq), x))

--- a/src/sparse.jl
+++ b/src/sparse.jl
@@ -233,10 +233,12 @@ function hints(eq, x, basis; plan = default_plan())
     return 0, Inf
 end
 
-# best_hints works is the link between numerical and symbolic integration.
-# It converts a symbolic integrad eq into a univariate expression, performs
-# symbolic-numeric integration, and the returns a list of symbolic ansatzes
-# corresponding to the solution
+"""
+    best_hints(eq, x, basis; plan = default_plan(), num_trials = 10)
+
+Select the smallest successful list of symbolic ansatz terms from repeated
+symbolic-numeric integrations of `eq` with respect to `x`.
+"""
 function best_hints(eq, x, basis; plan = default_plan(), num_trials = 10)
     H = []
     L = Int[]

--- a/src/special.jl
+++ b/src/special.jl
@@ -5,6 +5,11 @@ using SpecialFunctions
 
 E1(z) = Complex(expint(z))
 
+"""
+    Ei(z)
+
+Return the exponential integral evaluated at `z` as a complex value.
+"""
 function Ei(z)
     if z isa Real
         return Complex(-expint(Complex(-z)))
@@ -21,6 +26,11 @@ function Ei(z)
     return v
 end
 
+"""
+    Ci(z)
+
+Return the cosine integral evaluated at `z` as a complex value.
+"""
 function Ci(z)
     if z isa Real
         return Complex(cosint(z))
@@ -46,6 +56,11 @@ function Ci(z)
     return v
 end
 
+"""
+    Si(z)
+
+Return the sine integral evaluated at `z` as a complex value.
+"""
 function Si(z)
     if z isa Real
         return Complex(sinint(z))
@@ -66,6 +81,11 @@ function Si(z)
     return v
 end
 
+"""
+    Li(z)
+
+Return the logarithmic integral evaluated at `z` as a complex value.
+"""
 function Li(z)
     return Ei(log(z)) - Ei(log(2.0))
 end

--- a/test/qa/Project.toml
+++ b/test/qa/Project.toml
@@ -11,6 +11,6 @@ SymbolicNumericIntegration = {path = "../.."}
 [compat]
 Aqua = "0.8"
 JET = "0.9,0.10,0.11"
-SciMLTesting = "1.7"
+SciMLTesting = "2.1"
 Test = "1"
 julia = "1.10"

--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -5,6 +5,7 @@ using SciMLTesting
 run_qa(
     SymbolicNumericIntegration;
     explicit_imports = true,
+    api_docs_kwargs = (; rendered = true),
     jet_kwargs = (; target_defined_modules = true),
     # Aqua piracy: Base.signbit(::Complex)/signbit(::SymbolicUtils.Sym) in
     # src/integral.jl + DataDrivenSparse.active_set! in src/sparse.jl


### PR DESCRIPTION
Ignore this draft PR until reviewed by @ChrisRackauckas.

## Summary
- Update root and QA SciMLTesting compat to 2.1.
- Use SciMLTesting's shared public API docs QA path; rendered docs checks are enabled where package docs exist.
- Add or render missing public API docstrings/docs entries where needed and remove stale repo-local public-docs QA where present.

## Local Validation
- PASS: timeout 3600 ~/.juliaup/bin/julia +1.10 TOML parse over root/test/docs TOML files.
- PASS: no absolute QA [sources] paths and no test/Project.toml in this repo.
- PASS: timeout 3600 ~/.juliaup/bin/julia +1.12 -m Runic --check <changed .jl files>.
- PASS: GROUP=QA timeout 3600 ~/.juliaup/bin/julia +1.12 --project=. -e "using Pkg; Pkg.test()" (18 pass, 2 existing broken).
- PASS: timeout 3600 ~/.juliaup/bin/julia +1.12 --project=. -e "using Pkg; Pkg.test()".

