### PR TITLE
Release prep: bump SymbolicNumericIntegration to 1.11.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicNumericIntegration"
 uuid = "78aadeae-fbc0-11eb-17b6-c7ec0477ba9e"
 authors = ["Shahriar Iravanian <siravan@svtsim.com>"]
-version = "1.11.1"
+version = "1.11.2"
 
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"


### PR DESCRIPTION
Patch release for the accumulated docstring/QA/test changes since 1.11.1 (no functional/behavioral changes).