### PR TITLE
Release prep: bump version to 1.11.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicNumericIntegration"
 uuid = "78aadeae-fbc0-11eb-17b6-c7ec0477ba9e"
 authors = ["Shahriar Iravanian <siravan@svtsim.com>"]
-version = "1.11.2"
+version = "1.11.3"
 
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"


### PR DESCRIPTION
## Summary

The last registered version (1.11.2, git-tree-sha1 `c7ec0b4bd03746249dc035f2ef10fa3d9e087b45`) matches commit 4e07d07 ("Bump SymbolicNumericIntegration to 1.11.2 for release (#168)"). Since that commit, one commit has landed on `main` without a version bump:

- 3a2d99a — Remove redundant QA self source (#169): removes a `[sources]` self-path entry from `test/qa/Project.toml`. Test/QA-infrastructure only; no changes to package source code, exports, or public API.

## Diff since last release

```
test/qa/Project.toml | 3 ---
1 file changed, 3 deletions(-)
```

No changes to `[compat]` bounds and no usage of new APIs from any SciML-ecosystem dependency, so no compat bounds were touched.

## Bump type

PATCH: 1.11.2 -> 1.11.3. The only change since the last release is a test/QA-configuration cleanup with no effect on package behavior.