### PR TITLE
Raise ModelingToolkit extras floor to 11.26.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,6 +18,7 @@ TermInterface = "8ea1fca8-c5ef-4a55-8b96-4e9afe9c9a3c"
 
 [compat]
 DataDrivenDiffEq = "1.14.0"
+ModelingToolkit = "11.26.7"
 DataDrivenSparse = "0.2"
 DataStructures = "0.19"
 LinearAlgebra = "<0.0.1, 1"
@@ -34,9 +35,10 @@ Test = "1"
 julia = "1.10"
 
 [extras]
+ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SciMLTesting = "09d9d899-5365-40a9-917a-5f67fddea283"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["SafeTestsets", "SciMLTesting", "Test"]
+test = ["ModelingToolkit", "SafeTestsets", "SciMLTesting", "Test"]


### PR DESCRIPTION
**Please ignore this PR until it has been reviewed by @ChrisRackauckas.**

## What changed

Added extras `ModelingToolkit` with `[compat] 11.26.7` and listed it in `[targets].test`. No code or package version change.

## Why

Default-branch Downgrade is red while Tests are green ([run](https://github.com/SciML/SymbolicNumericIntegration.jl/actions/runs/31863193117)). The package does not declare ModelingToolkit; `DataDrivenDiffEq 1.15.0` pulls `ModelingToolkit 11.13.0` / `ModelingToolkitBase 1.29.1`, which fail to precompile on the same `ObservedGraphCache` / `DiCMOBiGraph` convert as DASSL.

`DataDrivenDiffEq 1.15.1` only floors MTK at 11.21, which is still capped to MTKBase ≤ 1.41. A direct extras floor of **11.26.7** is required so downgrade cannot land in that window.

## Verification

The failing CI log is the fail-before (MTK 11.13.0 / MTKBase 1.29.1, `Failed to precompile ModelingToolkitBase` via the convert `MethodError`).

Not verified here: the full SymbolicNumericIntegration suite or a live `julia-downgrade-compat` run.
