### PR TITLE
Bump versions for release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SymbolicNumericIntegration"
 uuid = "78aadeae-fbc0-11eb-17b6-c7ec0477ba9e"
 authors = ["Shahriar Iravanian <siravan@svtsim.com>"]
-version = "1.11.4"
+version = "1.12.0"
 
 [deps]
 DataDrivenDiffEq = "2445eb08-9709-466a-b3fc-47e12bd697a2"


### PR DESCRIPTION
Bumps the version(s) below so the src changes already merged to `main` can be registered in the General registry.

- SymbolicNumericIntegration: 1.11.4 -> 1.12.0

No code changes — version metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rmh6B9eoW3N8oCbuuVPVxJ
